### PR TITLE
Add vLLM OpenQA generation and LLM-as-judge scoring scripts

### DIFF
--- a/eval/generate_openqa_ans.py
+++ b/eval/generate_openqa_ans.py
@@ -1,0 +1,164 @@
+#!/usr/bin/env python3
+"""Generate OpenQA answers using vLLM offline batch inference."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Iterable, List, Optional
+
+from datasets import load_dataset
+from transformers import AutoTokenizer
+from vllm import LLM, SamplingParams
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Generate OpenQA answers with vLLM.")
+    parser.add_argument("--model", required=True, help="Model name or path.")
+    parser.add_argument(
+        "--dataset",
+        default=None,
+        help="HuggingFace dataset name (e.g. openqa).",
+    )
+    parser.add_argument(
+        "--dataset-config",
+        default=None,
+        help="Dataset configuration name.",
+    )
+    parser.add_argument("--split", default="train", help="Dataset split.")
+    parser.add_argument(
+        "--data-file",
+        default=None,
+        help="Optional local JSON/JSONL file to load instead of a HF dataset.",
+    )
+    parser.add_argument(
+        "--question-column",
+        default="question",
+        help="Column containing the question text.",
+    )
+    parser.add_argument(
+        "--output-file",
+        required=True,
+        help="Path to output JSONL file.",
+    )
+    parser.add_argument(
+        "--prompt-template",
+        default="{question}",
+        help="Prompt template with {question} placeholder.",
+    )
+    parser.add_argument(
+        "--system-prompt",
+        default=None,
+        help="Optional system prompt prepended to the user content.",
+    )
+    parser.add_argument(
+        "--use-chat-template",
+        action="store_true",
+        help="Apply the tokenizer chat template for formatting.",
+    )
+    parser.add_argument("--batch-size", type=int, default=32, help="Batch size.")
+    parser.add_argument("--max-tokens", type=int, default=256, help="Max tokens.")
+    parser.add_argument("--temperature", type=float, default=0.0, help="Temperature.")
+    parser.add_argument("--top-p", type=float, default=1.0, help="Top-p.")
+    parser.add_argument("--top-k", type=int, default=-1, help="Top-k.")
+    parser.add_argument("--seed", type=int, default=0, help="Random seed.")
+    parser.add_argument(
+        "--max-model-len",
+        type=int,
+        default=None,
+        help="Optional max model length override for vLLM.",
+    )
+    return parser.parse_args()
+
+
+def load_data(args: argparse.Namespace):
+    if args.data_file:
+        data_path = Path(args.data_file)
+        if not data_path.exists():
+            raise FileNotFoundError(f"Data file not found: {data_path}")
+        extension = data_path.suffix.lstrip(".")
+        if extension not in {"json", "jsonl"}:
+            raise ValueError("Only JSON/JSONL files are supported for --data-file.")
+        return load_dataset("json", data_files=str(data_path), split="train")
+
+    if not args.dataset:
+        raise ValueError("Provide --dataset or --data-file.")
+
+    dataset_kwargs = {"path": args.dataset}
+    if args.dataset_config:
+        dataset_kwargs["name"] = args.dataset_config
+    return load_dataset(**dataset_kwargs, split=args.split)
+
+
+def iter_batches(items: List[dict], batch_size: int) -> Iterable[List[dict]]:
+    for start in range(0, len(items), batch_size):
+        yield items[start : start + batch_size]
+
+
+def build_prompt(
+    question: str,
+    prompt_template: str,
+    system_prompt: Optional[str],
+    tokenizer: Optional[AutoTokenizer],
+    use_chat_template: bool,
+) -> str:
+    user_content = prompt_template.format(question=question)
+    if use_chat_template:
+        messages = []
+        if system_prompt:
+            messages.append({"role": "system", "content": system_prompt})
+        messages.append({"role": "user", "content": user_content})
+        return tokenizer.apply_chat_template(
+            messages,
+            tokenize=False,
+            add_generation_prompt=True,
+        )
+
+    if system_prompt:
+        return f"{system_prompt}\n\n{user_content}"
+    return user_content
+
+
+def main() -> None:
+    args = parse_args()
+    dataset = load_data(args)
+    records = list(dataset)
+
+    tokenizer = AutoTokenizer.from_pretrained(args.model) if args.use_chat_template else None
+
+    llm = LLM(model=args.model, max_model_len=args.max_model_len)
+    sampling_params = SamplingParams(
+        max_tokens=args.max_tokens,
+        temperature=args.temperature,
+        top_p=args.top_p,
+        top_k=args.top_k,
+        seed=args.seed,
+    )
+
+    output_path = Path(args.output_file)
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+
+    with output_path.open("w", encoding="utf-8") as output_file:
+        for batch in iter_batches(records, args.batch_size):
+            prompts = [
+                build_prompt(
+                    item[args.question_column],
+                    args.prompt_template,
+                    args.system_prompt,
+                    tokenizer,
+                    args.use_chat_template,
+                )
+                for item in batch
+            ]
+
+            results = llm.generate(prompts, sampling_params)
+            for item, result in zip(batch, results):
+                generated_text = result.outputs[0].text
+                merged = dict(item)
+                merged["generated_text"] = generated_text
+                output_file.write(json.dumps(merged, ensure_ascii=False) + "\n")
+
+
+if __name__ == "__main__":
+    main()

--- a/eval/generate_openqa_ans.py
+++ b/eval/generate_openqa_ans.py
@@ -5,12 +5,18 @@ from __future__ import annotations
 
 import argparse
 import json
+import logging
 from pathlib import Path
 from typing import Iterable, List, Optional
 
 from datasets import load_dataset
 from transformers import AutoTokenizer
 from vllm import LLM, SamplingParams
+from vllm.engine.arg_utils import EngineArgs
+import inspect
+
+
+LOGGER = logging.getLogger(__name__)
 
 
 def parse_args() -> argparse.Namespace:
@@ -26,7 +32,7 @@ def parse_args() -> argparse.Namespace:
         default=None,
         help="Dataset configuration name.",
     )
-    parser.add_argument("--split", default="train", help="Dataset split.")
+    parser.add_argument("--split", default="test", help="Dataset split.")
     parser.add_argument(
         "--data-file",
         default=None,
@@ -53,26 +59,132 @@ def parse_args() -> argparse.Namespace:
         help="Optional system prompt prepended to the user content.",
     )
     parser.add_argument(
-        "--use-chat-template",
+        "--disable-chat-template",
         action="store_true",
-        help="Apply the tokenizer chat template for formatting.",
+        help="Disable the tokenizer chat template for formatting.",
     )
     parser.add_argument("--batch-size", type=int, default=32, help="Batch size.")
-    parser.add_argument("--max-tokens", type=int, default=256, help="Max tokens.")
+    parser.add_argument("--max-tokens", type=int, default=2048, help="Max tokens.")
     parser.add_argument("--temperature", type=float, default=0.0, help="Temperature.")
-    parser.add_argument("--top-p", type=float, default=1.0, help="Top-p.")
+    parser.add_argument("--top-p", type=float, default=0.9, help="Top-p.")
     parser.add_argument("--top-k", type=int, default=-1, help="Top-k.")
     parser.add_argument("--seed", type=int, default=0, help="Random seed.")
     parser.add_argument(
         "--max-model-len",
         type=int,
-        default=None,
+        default=4096,
         help="Optional max model length override for vLLM.",
+    )
+    # vLLM Engine Arguments
+    parser.add_argument(
+        "--tensor-parallel-size",
+        type=int,
+        default=1,
+        help="Number of GPUs to use for tensor parallelism.",
+    )
+    parser.add_argument(
+        "--pipeline-parallel-size",
+        type=int,
+        default=1,
+        help="Number of GPUs to use for pipeline parallelism.",
+    )
+    parser.add_argument(
+        "--gpu-memory-utilization",
+        type=float,
+        default=0.9,
+        help="Fraction of GPU memory to use for vLLM.",
+    )
+    parser.add_argument(
+        "--max-num-batched-tokens",
+        type=int,
+        default=None,
+        help="Maximum number of batched tokens per iteration.",
+    )
+    parser.add_argument(
+        "--max-num-seqs",
+        type=int,
+        default=256,
+        help="Maximum number of sequences per iteration.",
+    )
+    parser.add_argument(
+        "--dtype",
+        type=str,
+        default="auto",
+        help="Data type for model weights (auto, float16, bfloat16, float32).",
+    )
+    parser.add_argument(
+        "--kv-cache-dtype",
+        type=str,
+        default="auto",
+        help="Data type for KV cache (auto, float16, bfloat16, float32).",
+    )
+    parser.add_argument(
+        "--load-format",
+        type=str,
+        default="auto",
+        help="Format to load model weights (auto, pt, safetensors, npcache).",
+    )
+    parser.add_argument(
+        "--trust-remote-code",
+        action="store_true",
+        help="Trust remote code from HuggingFace Hub.",
+    )
+    parser.add_argument(
+        "--download-dir",
+        type=str,
+        default=None,
+        help="Directory to download model weights to.",
+    )
+    parser.add_argument(
+        "--model-revision",
+        type=str,
+        default=None,
+        help="Revision of the model to use.",
+    )
+    parser.add_argument(
+        "--tokenizer-mode",
+        type=str,
+        default="auto",
+        help="Tokenizer mode (auto, slow).",
+    )
+    parser.add_argument(
+        "--tokenizer-revision",
+        type=str,
+        default=None,
+        help="Revision of the tokenizer to use.",
+    )
+    parser.add_argument(
+        "--swap-space",
+        type=int,
+        default=4,
+        help="CPU swap space size in GiB per GPU.",
+    )
+    parser.add_argument(
+        "--cpu-offload-gb",
+        type=int,
+        default=0,
+        help="Offload weights to CPU with this size in GiB.",
+    )
+    parser.add_argument(
+        "--enforce-eager",
+        action="store_true",
+        help="Enforce eager execution (no CUDA graph).",
+    )
+    parser.add_argument(
+        "--enable-prefix-caching",
+        action="store_true",
+        help="Enable prefix caching for multi-turn conversations.",
+    )
+    parser.add_argument(
+        "--enable-chunked-prefill",
+        action="store_true",
+        help="Enable chunked prefill execution.",
     )
     return parser.parse_args()
 
 
-def load_data(args: argparse.Namespace):
+def load_data(args: argparse.Namespace, dataset_config: Optional[str]):
+    LOGGER.info("Loading dataset.")
     if args.data_file:
         data_path = Path(args.data_file)
         if not data_path.exists():
@@ -80,15 +192,28 @@ def load_data(args: argparse.Namespace):
         extension = data_path.suffix.lstrip(".")
         if extension not in {"json", "jsonl"}:
             raise ValueError("Only JSON/JSONL files are supported for --data-file.")
-        return load_dataset("json", data_files=str(data_path), split="train")
+        dataset = load_dataset("json", data_files=str(data_path), split="train")
+        LOGGER.info("Loaded %d records from %s.", len(dataset), data_path)
+        return dataset
 
     if not args.dataset:
         raise ValueError("Provide --dataset or --data-file.")
 
     dataset_kwargs = {"path": args.dataset}
-    if args.dataset_config:
-        dataset_kwargs["name"] = args.dataset_config
-    return load_dataset(**dataset_kwargs, split=args.split)
+    if dataset_config:
+        dataset_kwargs["name"] = dataset_config
+    dataset = load_dataset(**dataset_kwargs, split=args.split)
+    if dataset_config:
+        LOGGER.info(
+            "Loaded %d records from %s (%s/%s).",
+            len(dataset),
+            args.dataset,
+            dataset_config,
+            args.split,
+        )
+    else:
+        LOGGER.info("Loaded %d records from %s (%s).", len(dataset), args.dataset, args.split)
+    return dataset
 
 
 def iter_batches(items: List[dict], batch_size: int) -> Iterable[List[dict]]:
@@ -120,14 +245,75 @@ def build_prompt(
     return user_content
 
 
+def count_lines(file_path: Path) -> int:
+    """Count the number of lines in a file."""
+    try:
+        with file_path.open("r", encoding="utf-8") as f:
+            return sum(1 for _ in f)
+    except Exception:
+        return 0
+
+
 def main() -> None:
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s %(levelname)s %(name)s - %(message)s",
+    )
     args = parse_args()
-    dataset = load_data(args)
-    records = list(dataset)
+    LOGGER.info("Starting OpenQA generation.")
+    if args.dataset_config:
+        dataset_configs = [
+            config.strip()
+            for config in args.dataset_config.split(",")
+            if config.strip()
+        ]
+    else:
+        dataset_configs = [None]
 
-    tokenizer = AutoTokenizer.from_pretrained(args.model) if args.use_chat_template else None
+    if not args.disable_chat_template:
+        LOGGER.info("Loading tokenizer for chat template: %s", args.model)
+        tokenizer = AutoTokenizer.from_pretrained(args.model)
+    else:
+        tokenizer = None
 
-    llm = LLM(model=args.model, max_model_len=args.max_model_len)
+    LOGGER.info("Loading vLLM model: %s", args.model)
+    # Get valid EngineArgs parameters
+    engine_args_sig = inspect.signature(EngineArgs.__init__)
+    valid_params = set(engine_args_sig.parameters.keys()) - {'self'}
+    
+    # Map argument names to EngineArgs parameter names
+    arg_mapping = {
+        'max_model_len': 'max_model_len',
+        'tensor_parallel_size': 'tensor_parallel_size',
+        'pipeline_parallel_size': 'pipeline_parallel_size',
+        'gpu_memory_utilization': 'gpu_memory_utilization',
+        'max_num_batched_tokens': 'max_num_batched_tokens',
+        'max_num_seqs': 'max_num_seqs',
+        'dtype': 'dtype',
+        'kv_cache_dtype': 'kv_cache_dtype',
+        'load_format': 'load_format',
+        'trust_remote_code': 'trust_remote_code',
+        'tokenizer_mode': 'tokenizer_mode',
+        'tokenizer_revision': 'tokenizer_revision',
+        'model_revision': 'revision',
+        'swap_space': 'swap_space',
+        'cpu_offload_gb': 'cpu_offload_gb',
+        'enforce_eager': 'enforce_eager',
+        'enable_prefix_caching': 'enable_prefix_caching',
+        'enable_chunked_prefill': 'enable_chunked_prefill',
+        'download_dir': 'download_dir',
+    }
+    
+    # Build engine arguments dynamically, only including valid parameters
+    engine_kwargs = {}
+    for arg_name, param_name in arg_mapping.items():
+        if param_name in valid_params and hasattr(args, arg_name):
+            value = getattr(args, arg_name)
+            if value is not None:  # Skip None values to use EngineArgs defaults
+                engine_kwargs[param_name] = value
+    
+    # Initialize LLM with model and engine kwargs
+    llm = LLM(model=args.model, **engine_kwargs)
     sampling_params = SamplingParams(
         max_tokens=args.max_tokens,
         temperature=args.temperature,
@@ -136,28 +322,81 @@ def main() -> None:
         seed=args.seed,
     )
 
-    output_path = Path(args.output_file)
-    output_path.parent.mkdir(parents=True, exist_ok=True)
+    base_output_path = Path(args.output_file)
+    base_output_path.parent.mkdir(parents=True, exist_ok=True)
 
-    with output_path.open("w", encoding="utf-8") as output_file:
-        for batch in iter_batches(records, args.batch_size):
-            prompts = [
-                build_prompt(
-                    item[args.question_column],
-                    args.prompt_template,
-                    args.system_prompt,
-                    tokenizer,
-                    args.use_chat_template,
+    for dataset_config in dataset_configs:
+        config_label = dataset_config or "default"
+        LOGGER.info("Processing dataset config: %s", config_label)
+        dataset = load_data(args, dataset_config)
+        records = list(dataset)
+        LOGGER.info("Prepared %d records for inference (config: %s).", len(records), config_label)
+
+        if dataset_config:
+            output_path = base_output_path.with_name(
+                f"{base_output_path.stem}_{dataset_config}{base_output_path.suffix}"
+            )
+        else:
+            output_path = base_output_path
+
+        # Check if output file already exists and has the correct number of lines
+        if output_path.exists():
+            existing_lines = count_lines(output_path)
+            if existing_lines == len(records):
+                LOGGER.info(
+                    "Output file %s already exists with %d lines (matches %d records). Skipping inference (config: %s)",
+                    output_path,
+                    existing_lines,
+                    len(records),
+                    config_label,
                 )
-                for item in batch
-            ]
+                continue
+            else:
+                LOGGER.warning(
+                    "Output file %s exists but has %d lines (expected %d records). Removing and restarting inference (config: %s)",
+                    output_path,
+                    existing_lines,
+                    len(records),
+                    config_label,
+                )
+                output_path.unlink()
 
-            results = llm.generate(prompts, sampling_params)
-            for item, result in zip(batch, results):
-                generated_text = result.outputs[0].text
-                merged = dict(item)
-                merged["generated_text"] = generated_text
-                output_file.write(json.dumps(merged, ensure_ascii=False) + "\n")
+        LOGGER.info("Writing outputs to %s (config: %s)", output_path, config_label)
+
+        with output_path.open("w", encoding="utf-8") as output_file:
+            total_batches = (len(records) + args.batch_size - 1) // args.batch_size
+            for batch_idx, batch in enumerate(iter_batches(records, args.batch_size), start=1):
+                LOGGER.info(
+                    "Generating batch %d/%d (config: %s)",
+                    batch_idx,
+                    total_batches,
+                    config_label,
+                )
+                prompts = [
+                    build_prompt(
+                        item[args.question_column],
+                        args.prompt_template,
+                        args.system_prompt,
+                        tokenizer,
+                        not args.disable_chat_template,
+                    )
+                    for item in batch
+                ]
+
+                LOGGER.info(
+                    "Running vLLM generation for %d prompts (config: %s).",
+                    len(prompts),
+                    config_label,
+                )
+                results = llm.generate(prompts, sampling_params)
+                for item, result, prompt in zip(batch, results, prompts):
+                    generated_text = result.outputs[0].text
+                    merged = dict(item)
+                    merged["prompt"] = prompt
+                    merged["generated_text"] = generated_text
+                    output_file.write(json.dumps(merged, ensure_ascii=False) + "\n")
+
+    LOGGER.info("Completed OpenQA generation.")
 
 
 if __name__ == "__main__":

--- a/eval/score_openqa_ans.py
+++ b/eval/score_openqa_ans.py
@@ -1,16 +1,25 @@
 #!/usr/bin/env python3
 """Score OpenQA answers using an LLM-as-judge with vLLM batch inference."""
 
-from __future__ import annotations
-
 import argparse
 import json
+import logging
 import re
 from pathlib import Path
 from typing import Iterable, List, Optional, Tuple
 
 from transformers import AutoTokenizer
 from vllm import LLM, SamplingParams
+from vllm.engine.arg_utils import EngineArgs
+import inspect
+
+# Configure logging
+logging.basicConfig(
+    level=logging.INFO,
+    format='%(asctime)s - %(levelname)s - %(message)s',
+    datefmt='%Y-%m-%d %H:%M:%S'
+)
+logger = logging.getLogger(__name__)
 
 SYSTEM_PROMPT = """
 You are the Judge for an Open-QA cybersecurity benchmark.
@@ -99,8 +108,8 @@ True or False
 def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(description="Score OpenQA answers with vLLM judge.")
     parser.add_argument("--model", required=True, help="Judge model name or path.")
-    parser.add_argument("--input-file", required=True, help="Input JSONL file.")
-    parser.add_argument("--output-file", required=True, help="Output JSONL file.")
+    parser.add_argument("--input", required=True, help="Input JSONL file or folder containing JSONL files.")
+    parser.add_argument("--output", required=True, help="Output JSONL file or folder for scored results.")
     parser.add_argument(
         "--question-column",
         default="question",
@@ -117,12 +126,12 @@ def parse_args() -> argparse.Namespace:
         help="Column name for the model answer.",
     )
     parser.add_argument(
-        "--use-chat-template",
+        "--disable-chat-template",
         action="store_true",
-        help="Apply the tokenizer chat template for formatting.",
+        help="Disable the tokenizer chat template for formatting.",
     )
-    parser.add_argument("--batch-size", type=int, default=16, help="Batch size.")
-    parser.add_argument("--max-tokens", type=int, default=512, help="Max tokens.")
+    parser.add_argument("--batch-size", type=int, default=32, help="Batch size.")
+    parser.add_argument("--max-tokens", type=int, default=2048, help="Max tokens.")
     parser.add_argument("--temperature", type=float, default=0.0, help="Temperature.")
     parser.add_argument("--top-p", type=float, default=1.0, help="Top-p.")
     parser.add_argument("--top-k", type=int, default=-1, help="Top-k.")
@@ -130,7 +139,7 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument(
         "--max-model-len",
         type=int,
-        default=None,
+        default=4096,
         help="Optional max model length override for vLLM.",
     )
     parser.add_argument(
@@ -138,6 +147,111 @@ def parse_args() -> argparse.Namespace:
         type=int,
         default=3,
         help="Max retries for parsing failures.",
+    )
+    # vLLM Engine Arguments
+    parser.add_argument(
+        "--tensor-parallel-size",
+        type=int,
+        default=1,
+        help="Number of GPUs to use for tensor parallelism.",
+    )
+    parser.add_argument(
+        "--pipeline-parallel-size",
+        type=int,
+        default=1,
+        help="Number of GPUs to use for pipeline parallelism.",
+    )
+    parser.add_argument(
+        "--gpu-memory-utilization",
+        type=float,
+        default=0.9,
+        help="Fraction of GPU memory to use for vLLM.",
+    )
+    parser.add_argument(
+        "--max-num-batched-tokens",
+        type=int,
+        default=None,
+        help="Maximum number of batched tokens per iteration.",
+    )
+    parser.add_argument(
+        "--max-num-seqs",
+        type=int,
+        default=256,
+        help="Maximum number of sequences per iteration.",
+    )
+    parser.add_argument(
+        "--dtype",
+        type=str,
+        default="auto",
+        help="Data type for model weights (auto, float16, bfloat16, float32).",
+    )
+    parser.add_argument(
+        "--kv-cache-dtype",
+        type=str,
+        default="auto",
+        help="Data type for KV cache (auto, float16, bfloat16, float32).",
+    )
+    parser.add_argument(
+        "--load-format",
+        type=str,
+        default="auto",
+        help="Format to load model weights (auto, pt, safetensors, npcache).",
+    )
+    parser.add_argument(
+        "--trust-remote-code",
+        action="store_true",
+        help="Trust remote code from HuggingFace Hub.",
+    )
+    parser.add_argument(
+        "--download-dir",
+        type=str,
+        default=None,
+        help="Directory to download model weights to.",
+    )
+    parser.add_argument(
+        "--model-revision",
+        type=str,
+        default=None,
+        help="Revision of the model to use.",
+    )
+    parser.add_argument(
+        "--tokenizer-mode",
+        type=str,
+        default="auto",
+        help="Tokenizer mode (auto, slow).",
+    )
+    parser.add_argument(
+        "--tokenizer-revision",
+        type=str,
+        default=None,
+        help="Revision of the tokenizer to use.",
+    )
+    parser.add_argument(
+        "--swap-space",
+        type=int,
+        default=4,
+        help="CPU swap space size in GiB per GPU.",
+    )
+    parser.add_argument(
+        "--cpu-offload-gb",
+        type=int,
+        default=0,
+        help="Offload weights to CPU with this size in GiB.",
+    )
+    parser.add_argument(
+        "--enforce-eager",
+        action="store_true",
+        help="Enforce eager execution (no CUDA graph).",
+    )
+    parser.add_argument(
+        "--enable-prefix-caching",
+        action="store_true",
+        help="Enable prefix caching for multi-turn conversations.",
+    )
+    parser.add_argument(
+        "--enable-chunked-prefill",
+        action="store_true",
+        help="Enable chunked prefill execution.",
     )
     return parser.parse_args()
 
@@ -198,14 +312,80 @@ def load_jsonl(path: Path) -> List[dict]:
 
 def main() -> None:
     args = parse_args()
-    input_path = Path(args.input_file)
-    output_path = Path(args.output_file)
+    logger.info("Starting OpenQA scoring with the following configuration:")
+    logger.info(f"  Model: {args.model}")
+    logger.info(f"  Input: {args.input}")
+    logger.info(f"  Output: {args.output}")
+    logger.info(f"  Batch size: {args.batch_size}")
+    logger.info(f"  Max tokens: {args.max_tokens}")
+    
+    input_path = Path(args.input)
+    output_path = Path(args.output)
 
-    rows = load_jsonl(input_path)
+    # Determine if input is a file or folder
+    if input_path.is_file():
+        # Single file mode
+        jsonl_files = [input_path]
+        is_folder_mode = False
+        logger.info(f"Single file mode: processing {input_path}")
+    elif input_path.is_dir():
+        # Folder mode
+        jsonl_files = sorted(input_path.glob("*.jsonl"))
+        if not jsonl_files:
+            logger.error(f"No JSONL files found in {input_path}")
+            return
+        is_folder_mode = True
+        logger.info(f"Folder mode: found {len(jsonl_files)} JSONL file(s) to process")
+    else:
+        logger.error(f"Input path does not exist: {input_path}")
+        return
 
-    tokenizer = AutoTokenizer.from_pretrained(args.model) if args.use_chat_template else None
+    tokenizer = AutoTokenizer.from_pretrained(args.model) if not args.disable_chat_template else None
+    if tokenizer:
+        logger.info("Tokenizer loaded successfully")
+    else:
+        logger.info("Chat template disabled, tokenizer not loaded")
 
-    llm = LLM(model=args.model, max_model_len=args.max_model_len)
+    # Get valid EngineArgs parameters
+    engine_args_sig = inspect.signature(EngineArgs.__init__)
+    valid_params = set(engine_args_sig.parameters.keys()) - {'self'}
+    
+    # Map argument names to EngineArgs parameter names
+    arg_mapping = {
+        'max_model_len': 'max_model_len',
+        'tensor_parallel_size': 'tensor_parallel_size',
+        'pipeline_parallel_size': 'pipeline_parallel_size',
+        'gpu_memory_utilization': 'gpu_memory_utilization',
+        'max_num_batched_tokens': 'max_num_batched_tokens',
+        'max_num_seqs': 'max_num_seqs',
+        'dtype': 'dtype',
+        'kv_cache_dtype': 'kv_cache_dtype',
+        'load_format': 'load_format',
+        'trust_remote_code': 'trust_remote_code',
+        'tokenizer_mode': 'tokenizer_mode',
+        'tokenizer_revision': 'tokenizer_revision',
+        'model_revision': 'revision',
+        'swap_space': 'swap_space',
+        'cpu_offload_gb': 'cpu_offload_gb',
+        'enforce_eager': 'enforce_eager',
+        'enable_prefix_caching': 'enable_prefix_caching',
+        'enable_chunked_prefill': 'enable_chunked_prefill',
+        'download_dir': 'download_dir',
+    }
+    
+    # Build engine arguments dynamically, only including valid parameters
+    engine_kwargs = {}
+    for arg_name, param_name in arg_mapping.items():
+        if param_name in valid_params and hasattr(args, arg_name):
+            value = getattr(args, arg_name)
+            if value is not None:  # Skip None values to use EngineArgs defaults
+                engine_kwargs[param_name] = value
+    
+    # Initialize LLM with model and engine kwargs
+    logger.info(f"Loading model: {args.model}")
+    logger.info(f"Engine configuration: {engine_kwargs}")
+    llm = LLM(model=args.model, **engine_kwargs)
+    logger.info("Model loaded successfully")
     sampling_params = SamplingParams(
         max_tokens=args.max_tokens,
         temperature=args.temperature,
@@ -214,53 +394,81 @@ def main() -> None:
         seed=args.seed,
     )
 
-    pending_indices = list(range(len(rows)))
-    trial = 0
-    last_raw = {}
+    # Process each JSONL file
+    for input_file in jsonl_files:
+        logger.info(f"Processing file: {input_file.name}")
+        rows = load_jsonl(input_file)
+        logger.info(f"  Loaded {len(rows)} rows from {input_file.name}")
+        
+        # Determine output path
+        if is_folder_mode:
+            current_output_path = output_path / input_file.name
+        else:
+            current_output_path = output_path
 
-    while pending_indices and trial < args.max_trials:
-        next_pending = []
-        for batch_indices in iter_batches(pending_indices, args.batch_size):
-            prompts = []
-            for idx in batch_indices:
-                row = rows[idx]
-                prompts.append(
-                    build_prompt(
-                        row[args.question_column],
-                        row[args.reference_column],
-                        row[args.model_answer_column],
-                        tokenizer,
-                        args.use_chat_template,
+        pending_indices = list(range(len(rows)))
+        trial = 0
+        last_raw = {}
+
+        while pending_indices and trial < args.max_trials:
+            logger.info(f"  Trial {trial + 1}/{args.max_trials}: {len(pending_indices)} items pending")
+            next_pending = []
+            for batch_indices in iter_batches(pending_indices, args.batch_size):
+                logger.debug(f"    Processing batch of {len(batch_indices)} items")
+                prompts = []
+                for idx in batch_indices:
+                    row = rows[idx]
+                    prompts.append(
+                        build_prompt(
+                            row[args.question_column],
+                            row[args.reference_column],
+                            row[args.model_answer_column],
+                            tokenizer,
+                            not args.disable_chat_template,
+                        )
                     )
-                )
 
-            results = llm.generate(prompts, sampling_params)
-            for idx, result in zip(batch_indices, results):
-                text = result.outputs[0].text.strip()
-                last_raw[idx] = text
-                parsed = parse_judge_output(text)
-                if parsed is None:
-                    next_pending.append(idx)
-                    continue
-                correctness, score = parsed
-                rows[idx]["judge_raw"] = text
-                rows[idx]["judge_correctness"] = correctness
-                rows[idx]["judge_score"] = score
+                results = llm.generate(prompts, sampling_params)
+                parsed_count = 0
+                for idx, result in zip(batch_indices, results):
+                    text = result.outputs[0].text.strip()
+                    last_raw[idx] = text
+                    parsed = parse_judge_output(text)
+                    if parsed is None:
+                        next_pending.append(idx)
+                        continue
+                    parsed_count += 1
+                    correctness, score = parsed
+                    rows[idx]["judge_raw"] = text
+                    rows[idx]["judge_correctness"] = correctness
+                    rows[idx]["judge_score"] = score
+                logger.debug(f"    Batch complete: {parsed_count}/{len(batch_indices)} items successfully parsed")
 
-        pending_indices = next_pending
-        trial += 1
+            pending_indices = next_pending
+            trial += 1
 
-    for idx in pending_indices:
-        rows[idx]["judge_raw"] = last_raw.get(idx)
-        rows[idx]["judge_correctness"] = None
-        rows[idx]["judge_score"] = None
-        rows[idx]["judge_parse_error"] = True
+        for idx in pending_indices:
+            rows[idx]["judge_raw"] = last_raw.get(idx)
+            rows[idx]["judge_correctness"] = None
+            rows[idx]["judge_score"] = None
+            rows[idx]["judge_parse_error"] = True
+        
+        if pending_indices:
+            logger.warning(f"  {len(pending_indices)} items failed to parse after {args.max_trials} trials")
 
-    output_path.parent.mkdir(parents=True, exist_ok=True)
-    with output_path.open("w", encoding="utf-8") as output_file:
-        for row in rows:
-            output_file.write(json.dumps(row, ensure_ascii=False) + "\n")
+        current_output_path.parent.mkdir(parents=True, exist_ok=True)
+        with current_output_path.open("w", encoding="utf-8") as output_file:
+            for row in rows:
+                output_file.write(json.dumps(row, ensure_ascii=False) + "\n")
+        
+        logger.info(f"  Saved results to {current_output_path}")
 
 
 if __name__ == "__main__":
+    logger.info("=" * 60)
+    logger.info("Starting OpenQA Answer Scoring Process")
+    logger.info("=" * 60)
     main()
+    logger.info("=" * 60)
+    logger.info("Scoring process completed")
+    logger.info("=" * 60)

--- a/eval/score_openqa_ans.py
+++ b/eval/score_openqa_ans.py
@@ -1,0 +1,266 @@
+#!/usr/bin/env python3
+"""Score OpenQA answers using an LLM-as-judge with vLLM batch inference."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+from pathlib import Path
+from typing import Iterable, List, Optional, Tuple
+
+from transformers import AutoTokenizer
+from vllm import LLM, SamplingParams
+
+SYSTEM_PROMPT = """
+You are the Judge for an Open-QA cybersecurity benchmark.
+
+## Inputs
+- question: the final user-facing prompt
+- reference_answer: the ground-truth answer
+- model_answer: the response produced by the evaluated model
+
+## Goal
+Evaluate model_answer on two aspects: (1) factual correctness, and (2) overall answer quality (0-10).
+
+---
+
+## Checklist
+
+1) Correctness
+- Is the answer factually accurate?
+- Does it align with the reference_answer and grounded cybersecurity knowledge?
+- Any hallucinations, contradictions, or false claims?
+
+Output rule for correctness:
+- True if correct and grounded
+- False if factually incorrect, hallucinated, contradicted, or clearly wrong
+
+2) Answer Quality Score (0-10)
+Rate overall quality only if at least partially correct:
+- Helpfulness (does it answer the question?)
+- Relevance (focused and on-topic)
+- Depth (reasoning or understanding)
+- Level of detail (complete and specific enough)
+
+Scoring guide:
+- 10: perfect — accurate, complete, deep, fully relevant
+- 8-9: strong — minor omissions or small inaccuracies
+- 6-7: moderate — useful but lacking depth or detail
+- 4-5: weak — vague, shallow, or incomplete
+- 1-3: poor — limited usefulness or clarity
+- 0: invalid or gibberish
+
+---
+
+## Instructions
+- Use chain-of-thought privately, but present only a final analysis in <analysis>.  
+- Be strict on correctness: any factual error → correctness=False. If correctness=False, cap score at 3 or lower.  
+- If correct but shallow, keep correctness=True and assign a lower score.
+
+---
+
+## Output Format
+Return exactly these three blocks in order. Do not add text outside the tags.
+
+<analysis>
+Free-form justification. You may write anything here such as step-by-step reasoning, comparisons, errors spotted, strengths, weaknesses, etc. between the model_answer and reference_answe.
+Make sure your analysis is detailed and covers all aspects of the evaluation checklist.
+
+### Correctness
+Analysis and justification for the correctness evaluation.
+
+### Answer Quality Score
+Analysis and justification for the answer quality score.
+
+#### Helpfulness
+Justification for the helpfulness aspect.
+
+#### Relevance
+Justification for the relevance aspect.
+
+#### Depth
+Justification for the depth aspect.
+
+#### Level of Detail
+Justification for the level of detail aspect.
+</analysis>
+
+<correctness>
+True or False
+</correctness>
+
+<score>
+0-10 (integer only)
+</score>
+""".strip()
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Score OpenQA answers with vLLM judge.")
+    parser.add_argument("--model", required=True, help="Judge model name or path.")
+    parser.add_argument("--input-file", required=True, help="Input JSONL file.")
+    parser.add_argument("--output-file", required=True, help="Output JSONL file.")
+    parser.add_argument(
+        "--question-column",
+        default="question",
+        help="Column name for the question.",
+    )
+    parser.add_argument(
+        "--reference-column",
+        default="reference_answer",
+        help="Column name for the reference answer.",
+    )
+    parser.add_argument(
+        "--model-answer-column",
+        default="generated_text",
+        help="Column name for the model answer.",
+    )
+    parser.add_argument(
+        "--use-chat-template",
+        action="store_true",
+        help="Apply the tokenizer chat template for formatting.",
+    )
+    parser.add_argument("--batch-size", type=int, default=16, help="Batch size.")
+    parser.add_argument("--max-tokens", type=int, default=512, help="Max tokens.")
+    parser.add_argument("--temperature", type=float, default=0.0, help="Temperature.")
+    parser.add_argument("--top-p", type=float, default=1.0, help="Top-p.")
+    parser.add_argument("--top-k", type=int, default=-1, help="Top-k.")
+    parser.add_argument("--seed", type=int, default=0, help="Random seed.")
+    parser.add_argument(
+        "--max-model-len",
+        type=int,
+        default=None,
+        help="Optional max model length override for vLLM.",
+    )
+    parser.add_argument(
+        "--max-trials",
+        type=int,
+        default=3,
+        help="Max retries for parsing failures.",
+    )
+    return parser.parse_args()
+
+
+def iter_batches(items: List[int], batch_size: int) -> Iterable[List[int]]:
+    for start in range(0, len(items), batch_size):
+        yield items[start : start + batch_size]
+
+
+def build_prompt(
+    question: str,
+    reference_answer: str,
+    model_answer: str,
+    tokenizer: Optional[AutoTokenizer],
+    use_chat_template: bool,
+) -> str:
+    user_prompt = (
+        f"Question:\n```\n{question}\n```\n\n"
+        f"Reference Answer:\n```\n{reference_answer}\n```\n\n"
+        f"Model Answer:\n```\n{model_answer}\n```"
+    )
+
+    if use_chat_template:
+        messages = [
+            {"role": "system", "content": SYSTEM_PROMPT},
+            {"role": "user", "content": user_prompt},
+        ]
+        return tokenizer.apply_chat_template(
+            messages,
+            tokenize=False,
+            add_generation_prompt=True,
+        )
+
+    return f"{SYSTEM_PROMPT}\n\n{user_prompt}"
+
+
+CORRECTNESS_RE = re.compile(r"<correctness>\s*(True|False)\s*</correctness>", re.DOTALL)
+SCORE_RE = re.compile(r"<score>\s*(\d{1,2})\s*</score>", re.DOTALL)
+
+
+def parse_judge_output(text: str) -> Optional[Tuple[bool, int]]:
+    correctness_match = CORRECTNESS_RE.search(text)
+    score_match = SCORE_RE.search(text)
+    if not correctness_match or not score_match:
+        return None
+
+    correctness_value = correctness_match.group(1) == "True"
+    score_value = int(score_match.group(1))
+    if score_value < 0 or score_value > 10:
+        return None
+    return correctness_value, score_value
+
+
+def load_jsonl(path: Path) -> List[dict]:
+    with path.open("r", encoding="utf-8") as file:
+        return [json.loads(line) for line in file if line.strip()]
+
+
+def main() -> None:
+    args = parse_args()
+    input_path = Path(args.input_file)
+    output_path = Path(args.output_file)
+
+    rows = load_jsonl(input_path)
+
+    tokenizer = AutoTokenizer.from_pretrained(args.model) if args.use_chat_template else None
+
+    llm = LLM(model=args.model, max_model_len=args.max_model_len)
+    sampling_params = SamplingParams(
+        max_tokens=args.max_tokens,
+        temperature=args.temperature,
+        top_p=args.top_p,
+        top_k=args.top_k,
+        seed=args.seed,
+    )
+
+    pending_indices = list(range(len(rows)))
+    trial = 0
+    last_raw = {}
+
+    while pending_indices and trial < args.max_trials:
+        next_pending = []
+        for batch_indices in iter_batches(pending_indices, args.batch_size):
+            prompts = []
+            for idx in batch_indices:
+                row = rows[idx]
+                prompts.append(
+                    build_prompt(
+                        row[args.question_column],
+                        row[args.reference_column],
+                        row[args.model_answer_column],
+                        tokenizer,
+                        args.use_chat_template,
+                    )
+                )
+
+            results = llm.generate(prompts, sampling_params)
+            for idx, result in zip(batch_indices, results):
+                text = result.outputs[0].text.strip()
+                last_raw[idx] = text
+                parsed = parse_judge_output(text)
+                if parsed is None:
+                    next_pending.append(idx)
+                    continue
+                correctness, score = parsed
+                rows[idx]["judge_raw"] = text
+                rows[idx]["judge_correctness"] = correctness
+                rows[idx]["judge_score"] = score
+
+        pending_indices = next_pending
+        trial += 1
+
+    for idx in pending_indices:
+        rows[idx]["judge_raw"] = last_raw.get(idx)
+        rows[idx]["judge_correctness"] = None
+        rows[idx]["judge_score"] = None
+        rows[idx]["judge_parse_error"] = True
+
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    with output_path.open("w", encoding="utf-8") as output_file:
+        for row in rows:
+            output_file.write(json.dumps(row, ensure_ascii=False) + "\n")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
### Motivation
- Provide efficient offline batch generation of OpenQA model answers using vLLM to produce a JSONL of model outputs for downstream evaluation.
- Provide an automated LLM-as-judge scoring tool to assess factual correctness and quality (0-10) for generated answers using the same vLLM backend.

### Description
- Add `eval/generate_openqa_ans.py` which loads a HuggingFace dataset or local JSON/JSONL, formats prompts (optional chat/system template), runs batched vLLM inference, and writes records with a `generated_text` field to an output JSONL file.
- Add `eval/score_openqa_ans.py` which reads the generated JSONL, constructs a judge prompt using the provided system template, runs batched vLLM inference, parses `<correctness>` and `<score>` via regex, retries failed parses up to `--max-trials`, and appends `judge_raw`, `judge_correctness`, `judge_score`, and `judge_parse_error` when applicable.
- Both scripts expose CLI arguments for model, batching, sampling (`--max-tokens`, `--temperature`, `--top-p`, `--top-k`, `--seed`), optional chat-template formatting via `--use-chat-template`, and an optional `--max-model-len` override for vLLM usage.
- Scripts rely on `datasets`, `transformers`, and `vllm` for data loading, tokenizer chat templates, and inference respectively.

### Testing
- No automated tests were executed as part of this change (no CI/test run was requested or performed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6981f86d5a40832583c13e7ea72ca4f3)